### PR TITLE
Add basic CI for publishing a basic dockerfile 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ steps.checkout.env.GITHUB_WORKSPACE }}
-          file: "${GITHUB_WORKSPACE}/docker/release.Dockerfile"
+          file: "${{ steps.checkout.env.GITHUB_WORKSPACE }}/docker/release.Dockerfile"
           push: true
           tags: npmaile/hoot:latest
       - name: Image Digest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,6 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: print secret
-        run: echo ${{ secrets.DOCKERHUB_USERNAME }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -33,15 +31,17 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: github checkout
+        uses: actions/checkout@v2
       - name: Build and Push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          context: $GITHUB_WORKSPACE
-          file: $GITHUB_WORKSPACE/docker/release.Dockerfile
+          context: ${GITHUB_WORKSPACE}
+          file: "${GITHUB_WORKSPACE}/docker/release.Dockerfile"
           push: true
           tags: npmaile/hoot:latest
       - name: Image Digest
         run: echo ${{ steps.docker_build.outputs.digest }}
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,15 +33,14 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: github checkout
         uses: actions/checkout@v2
+        id: checkout
       - name: Build and Push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          context: ${GITHUB_WORKSPACE}
+          context: ${{ steps.checkout.env.GITHUB_WORKSPACE }}
           file: "${GITHUB_WORKSPACE}/docker/release.Dockerfile"
           push: true
           tags: npmaile/hoot:latest
       - name: Image Digest
         run: echo ${{ steps.docker_build.outputs.digest }}
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,52 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and Push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: $GITHUB_WORKSPACE
+          file: $GITHUB_WORKSPACE/docker/release.Dockerfile
+          push: true
+          tags: npmaile/Hoot:latest
+      - name: Image Digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          cd $GITHUB_WORKSPACE
+          docker build -t "hoot-dev:${IMAGE_VERSION}" -f <./docker/dev.Dockerfile> .
+          

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,6 @@ jobs:
           context: ${{ steps.checkout.env.GITHUB_WORKSPACE }}
           file: "${{ steps.checkout.env.GITHUB_WORKSPACE }}/docker/release.Dockerfile"
           push: true
-          tags: npmaile/hoot:latest
+          tags: ${{ secrets.DOCKER_ORG_NAME }}/hoot:latest
       - name: Image Digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: print secret
-        run: echo ${{secrets.DOCKERHUB_USERNAME
+        run: echo ${{ secrets.DOCKERHUB_USERNAME }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.docker.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.docker.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.docker_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.docker_DOCKERHUB_TOKEN }}
       - name: Build and Push
         id: docker_build
         uses: docker/build-push-action@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      - name: print secret
+        run: echo ${{secrets.DOCKERHUB_USERNAME
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.docker.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.docker.DOCKERHUB_TOKEN }}
       - name: Build and Push
         id: docker_build
         uses: docker/build-push-action@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.docker_DOCKERHUB_USERNAME }}
-          password: ${{ secrets.docker_DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and Push
         id: docker_build
         uses: docker/build-push-action@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,15 +40,8 @@ jobs:
           context: $GITHUB_WORKSPACE
           file: $GITHUB_WORKSPACE/docker/release.Dockerfile
           push: true
-          tags: npmaile/Hoot:latest
+          tags: npmaile/hoot:latest
       - name: Image Digest
         run: echo ${{ steps.docker_build.outputs.digest }}
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
-        run: |
-          cd $GITHUB_WORKSPACE
-          docker build -t "hoot-dev:${IMAGE_VERSION}" -f <./docker/dev.Dockerfile> .
-          

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -1,0 +1,1 @@
+//more stuff to come

--- a/docker/release.Dockerfile
+++ b/docker/release.Dockerfile
@@ -1,0 +1,23 @@
+M node:lts-alpine
+
+# install simple http server for serving static content
+RUN npm install -g http-server
+
+# make the 'app' folder the current working directory
+WORKDIR /app
+
+# copy both 'package.json' and 'package-lock.json' (if available)
+COPY package*.json ./
+
+# install project dependencies
+RUN npm install
+
+# copy project files and folders to the current working directory (i.e. 'app' folder)
+COPY . .
+
+# build app for production with minification
+RUN npm run build
+
+EXPOSE 8080
+CMD [ "http-server", "dist" ]
+

--- a/docker/release.Dockerfile
+++ b/docker/release.Dockerfile
@@ -1,4 +1,4 @@
-M node:lts-alpine
+FROM node:lts-alpine
 
 # install simple http server for serving static content
 RUN npm install -g http-server


### PR DESCRIPTION
This will publish any pushes to the Hoot repository to dockerhub as image hoot:latest as a basic hoot docker image.

More to come soon. 

Before this will work properly, the following need to be added to github repository secrets for the project (won't affect anything to add them early)

DOCKERHUB_TOKEN - a token generated with permissions under the docker org the image is to be published under. 
DOCKERHUB_USERNAME - someone's username for dockerhub with ability to push to the docker org that the image will be published under. mine is "npmaile"
DOCKER_ORG_NAME - what the first part of the docker image name is likely going to be "projecthoot" for projecthoot/hoot:latest

more info on github actions can be found [here](https://github.com/features/actions)
more info on github secrets can be found [here](https://docs.github.com/en/actions/reference/encrypted-secrets)
more info on dockerhub tokens can be found [here](https://docs.docker.com/docker-hub/access-tokens/)
