### PR TITLE
fixes #65

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -69,7 +69,7 @@
       <TooltipButton
         :icon="$vuetify.theme.dark ? 'mdi-flashlight-off' : 'mdi-flashlight'"
         hover="Toggle Dark/Light Mode"
-        @click="toggleDark"
+        @click="setDark(!$vuetify.theme.dark)"
       /><v-menu
         v-model="searchwindow"
         :close-on-click="false"
@@ -149,13 +149,20 @@ export default {
     searchwindow: false,
     drawer: false,
   }),
-  fetch() {
+  mounted() {
     const isDarkTheme = this.$auth.$storage.getUniversal('isDarkTheme')
-    this.$vuetify.theme.dark = isDarkTheme
+    const darkMediaQuery = window.matchMedia('(prefers-color-scheme: light)')
+    if (isDarkTheme !== undefined) {
+      this.setDark(isDarkTheme)
+    } else {
+      darkMediaQuery.matches ? this.setDark(false) : this.setDark(true)
+    }
+    darkMediaQuery.addEventListener('change', (e) => {
+      this.$vuetify.theme.dark = !this.$vuetify.theme.dark
+    })
   },
   methods: {
-    toggleDark() {
-      const val = !this.$vuetify.theme.dark
+    setDark(val) {
       this.$vuetify.theme.dark = val
       this.$auth.$storage.setUniversal('isDarkTheme', val)
     },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -123,6 +123,7 @@ export default {
   vuetify: {
     customVariables: ['~/assets/variables.scss'],
     theme: {
+      dark: true,
       themes: {
         light: {
           primary: colors.yellow.darken3, // '#DDBD37', // gold

--- a/store/index.js
+++ b/store/index.js
@@ -14,6 +14,9 @@ export const mutations = {
 export const actions = {
   nuxtServerInit(_, { $auth, $vuetify }) {
     // updating vuetify theme here so the theme is consistent during SSR
-    $vuetify.theme.dark = $auth.$storage.getUniversal('isDarkTheme')
+    const isDarkTheme = $auth.$storage.getUniversal('isDarkTheme')
+    if (isDarkTheme !== undefined) {
+      $vuetify.theme.dark = isDarkTheme
+    }
   },
 }


### PR DESCRIPTION
- Fixes Dark Mode changes not being respected after refresh
- Updates dark mode logic to:
    1. Check if they've set a preference and use it
    2. Check their system preference and use it
    3. Default to Dark mode
         - Defaulting to Dark Mode means that, on first render, if their system preference is "light" then they'll see everything in dark mode for a split second until the client updates the preference to "light"